### PR TITLE
Restrict manifest paths to be in the kustomize directory tree

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
 
 	"github.com/open-cluster-management/policy-generator-plugin/internal"
 	"github.com/spf13/pflag"
@@ -50,13 +51,18 @@ func errorAndExit(msg string, formatArgs ...interface{}) {
 // It reads the file, processes and validates the contents, uses the contents to
 // generate policies, and returns the generated policies as a byte array.
 func processGeneratorConfig(filePath string) []byte {
+	cwd, err := os.Getwd()
+	if err != nil {
+		errorAndExit("failed to determine the current directory: %v", err)
+	}
+
 	p := internal.Plugin{}
 	fileData, err := ioutil.ReadFile(filePath)
 	if err != nil {
 		errorAndExit("failed to read file '%s': %s", filePath, err)
 	}
 
-	err = p.Config(fileData)
+	err = p.Config(fileData, path.Dir(cwd))
 	if err != nil {
 		errorAndExit("error processing the PolicyGenerator file '%s': %s", filePath, err)
 	}

--- a/docs/policygenerator-reference.yaml
+++ b/docs/policygenerator-reference.yaml
@@ -76,7 +76,9 @@ policies:
     # Required. The list of Kubernetes resource object manifests to include in the policy.
     manifests:
         # Required. Path to a single file or a flat directory of files relative to the
-        # kustomization.yaml file.
+        # kustomization.yaml file. This path cannot be in a directory outside of the directory with
+        # the kustomization.yaml file. Subdirectories within the directory with kustomization.yaml
+        # file are allowed.
       - path: ""
         # Optional. (See policy[0].complianceType for description.)
         complianceType: "musthave"

--- a/internal/plugin_config_test.go
+++ b/internal/plugin_config_test.go
@@ -78,7 +78,7 @@ policies:
 	)
 
 	p := Plugin{}
-	err := p.Config([]byte(exampleConfig))
+	err := p.Config([]byte(exampleConfig), tmpDir)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -167,7 +167,7 @@ policies:
 		configMapPath,
 	)
 	p := Plugin{}
-	err := p.Config([]byte(defaultsConfig))
+	err := p.Config([]byte(defaultsConfig), tmpDir)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -220,7 +220,7 @@ policies:
     - path: input/configmap.yaml
 `
 	p := Plugin{}
-	err := p.Config([]byte(config))
+	err := p.Config([]byte(config), "")
 	if err == nil {
 		t.Fatal("Expected an error but did not get one")
 	}
@@ -229,7 +229,7 @@ policies:
 	assertEqual(t, err.Error(), expected)
 }
 
-func TestCreateInvalidPolicyName(t *testing.T) {
+func TestConfigInvalidPolicyName(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
 	createConfigMap(t, tmpDir, "configmap.yaml")
@@ -253,12 +253,49 @@ policies:
 	)
 
 	p := Plugin{}
-	err := p.Config([]byte(defaultsConfig))
+	err := p.Config([]byte(defaultsConfig), tmpDir)
 	if err == nil {
 		t.Fatal("Expected an error but did not get one")
 	}
 
 	expected := fmt.Sprintf("the policy namespace and name cannot be more than 63 characters: %s.%s", policyNS, policyName)
+	assertEqual(t, err.Error(), expected)
+}
+
+func TestConfigInvalidPath(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	createConfigMap(t, tmpDir, "configmap.yaml")
+	configMapPath := path.Join(tmpDir, "configmap.yaml")
+	policyNS := "my-policies"
+	policyName := "policy-app-config"
+	defaultsConfig := fmt.Sprintf(
+		`
+apiVersion: policy.open-cluster-management.io/v1
+kind: PolicyGenerator
+metadata:
+  name: policy-generator-name
+policyDefaults:
+  namespace: %s
+policies:
+- name: %s
+  manifests:
+    - path: %s
+`,
+		policyNS, policyName, configMapPath,
+	)
+
+	p := Plugin{}
+	// Provide a base directory that isn't in the same directory tree as tmpDir.
+	baseDir := t.TempDir()
+	err := p.Config([]byte(defaultsConfig), baseDir)
+	if err == nil {
+		t.Fatal("Expected an error but did not get one")
+	}
+
+	expected := fmt.Sprintf(
+		"the manifest path %s is not in the same directory tree as the kustomization.yaml file", configMapPath,
+	)
 	assertEqual(t, err.Error(), expected)
 }
 
@@ -273,7 +310,7 @@ policyDefaults:
   namespace: my-policies
 `
 	p := Plugin{}
-	err := p.Config([]byte(config))
+	err := p.Config([]byte(config), "")
 	if err == nil {
 		t.Fatal("Expected an error but did not get one")
 	}
@@ -305,7 +342,7 @@ policies:
 		path.Join(tmpDir, "configmap.yaml"),
 	)
 	p := Plugin{}
-	err := p.Config([]byte(config))
+	err := p.Config([]byte(config), tmpDir)
 	if err == nil {
 		t.Fatal("Expected an error but did not get one")
 	}
@@ -338,7 +375,7 @@ policies:
 		path.Join(tmpDir, "configmap.yaml"),
 	)
 	p := Plugin{}
-	err := p.Config([]byte(config))
+	err := p.Config([]byte(config), tmpDir)
 	if err == nil {
 		t.Fatal("Expected an error but did not get one")
 	}
@@ -371,7 +408,7 @@ policies:
 		path.Join(tmpDir, "configmap.yaml"),
 	)
 	p := Plugin{}
-	err := p.Config([]byte(config))
+	err := p.Config([]byte(config), tmpDir)
 	if err == nil {
 		t.Fatal("Expected an error but did not get one")
 	}
@@ -401,7 +438,7 @@ policies:
     - path: input/configmap.yaml
 `
 	p := Plugin{}
-	err := p.Config([]byte(config))
+	err := p.Config([]byte(config), "")
 	if err == nil {
 		t.Fatal("Expected an error but did not get one")
 	}
@@ -435,7 +472,7 @@ policies:
 		path.Join(tmpDir, "configmap.yaml"),
 	)
 	p := Plugin{}
-	err := p.Config([]byte(config))
+	err := p.Config([]byte(config), tmpDir)
 	if err == nil {
 		t.Fatal("Expected an error but did not get one")
 	}
@@ -467,7 +504,7 @@ policies:
     - path: input/configmap.yaml
 `
 	p := Plugin{}
-	err := p.Config([]byte(config))
+	err := p.Config([]byte(config), "")
 	if err == nil {
 		t.Fatal("Expected an error but did not get one")
 	}
@@ -501,7 +538,7 @@ policies:
 		path.Join(tmpDir, "configmap.yaml"),
 	)
 	p := Plugin{}
-	err := p.Config([]byte(config))
+	err := p.Config([]byte(config), tmpDir)
 	if err == nil {
 		t.Fatal("Expected an error but did not get one")
 	}
@@ -539,7 +576,7 @@ policies:
 		path.Join(tmpDir, "configmap.yaml"), path.Join(tmpDir, "configmap.yaml"),
 	)
 	p := Plugin{}
-	err := p.Config([]byte(config))
+	err := p.Config([]byte(config), tmpDir)
 	if err == nil {
 		t.Fatal("Expected an error but did not get one")
 	}
@@ -570,7 +607,7 @@ policies:
 		path.Join(tmpDir, "configmap.yaml"),
 	)
 	p := Plugin{}
-	err := p.Config([]byte(config))
+	err := p.Config([]byte(config), tmpDir)
 	if err == nil {
 		t.Fatal("Expected an error but did not get one")
 	}
@@ -605,7 +642,7 @@ policies:
 		path.Join(tmpDir, "configmap2.yaml"),
 	)
 	p := Plugin{}
-	err := p.Config([]byte(config))
+	err := p.Config([]byte(config), tmpDir)
 	if err == nil {
 		t.Fatal("Expected an error but did not get one")
 	}
@@ -628,7 +665,7 @@ policies:
 - name: policy-app-config
 `
 	p := Plugin{}
-	err := p.Config([]byte(config))
+	err := p.Config([]byte(config), "")
 	if err == nil {
 		t.Fatal("Expected an error but did not get one")
 	}
@@ -658,7 +695,7 @@ policies:
 		manifestPath,
 	)
 	p := Plugin{}
-	err := p.Config([]byte(config))
+	err := p.Config([]byte(config), tmpDir)
 	if err == nil {
 		t.Fatal("Expected an error but did not get one")
 	}
@@ -688,7 +725,7 @@ policies:
 		path.Join(tmpDir, "configmap.yaml"),
 	)
 	p := Plugin{}
-	err := p.Config([]byte(config))
+	err := p.Config([]byte(config), tmpDir)
 	if err == nil {
 		t.Fatal("Expected an error but did not get one")
 	}
@@ -721,7 +758,7 @@ policies:
 		path.Join(tmpDir, "configmap.yaml"),
 	)
 	p := Plugin{}
-	err := p.Config([]byte(config))
+	err := p.Config([]byte(config), tmpDir)
 	if err == nil {
 		t.Fatal("Expected an error but did not get one")
 	}

--- a/internal/plugin_test.go
+++ b/internal/plugin_test.go
@@ -16,6 +16,7 @@ func TestGenerate(t *testing.T) {
 	tmpDir := t.TempDir()
 	createConfigMap(t, tmpDir, "configmap.yaml")
 	p := Plugin{}
+	p.baseDirectory = tmpDir
 	p.PlacementBindingDefaults.Name = "my-placement-binding"
 	p.PolicyDefaults.Placement.Name = "my-placement-rule"
 	p.PolicyDefaults.Namespace = "my-policies"
@@ -157,6 +158,7 @@ func TestGenerateSeparateBindings(t *testing.T) {
 	tmpDir := t.TempDir()
 	createConfigMap(t, tmpDir, "configmap.yaml")
 	p := Plugin{}
+	p.baseDirectory = tmpDir
 	p.PolicyDefaults.Namespace = "my-policies"
 	policyConf := types.PolicyConfig{
 		Name: "policy-app-config",
@@ -302,6 +304,7 @@ func TestGenerateMissingBindingName(t *testing.T) {
 	tmpDir := t.TempDir()
 	createConfigMap(t, tmpDir, "configmap.yaml")
 	p := Plugin{}
+	p.baseDirectory = tmpDir
 	p.PlacementBindingDefaults.Name = ""
 	p.PolicyDefaults.Placement.Name = "my-placement-rule"
 	p.PolicyDefaults.Namespace = "my-policies"


### PR DESCRIPTION
This is an added security measure so that the user cannot specify a
manifest path that is not related to their Kustomize configuration.

Relates:
https://github.com/open-cluster-management/backlog/issues/18236